### PR TITLE
Tiny bug fix from "Optional overhead camera mount for single and bi-manual setups" PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Note: we removed to auto-calibration at the end in favor of manual calibration w
 
 **Tactile sensing**: You can find an AnySkin tactile sensor for the SO100 here: [WOWROBO](https://shop.wowrobo.com/products/enhanced-anyskin-premium-crafted-editionwowskin)
 
-**Overhead Camera Mount**: You can mount an overhead camera for one or two (bi-manual) arm setups: [Instructions](Optional/Overhead_cam_Mount)
+**Overhead Camera Mount**: You can mount an overhead camera for one or two (bi-manual) arm setups: [Instructions](Optional/Overhead_Cam_Mount)
 
 **Raised leader base**: You can raise the base of leader arm for easier teleoperation near the ground plane by printing this extension: `Optional/Raised_Leader_Base_SO100/SO100 Leader Base Extension.stl`
 


### PR DESCRIPTION
Hi! Thank you again for pushing through the "Optional overhead camera mount for single and bi-manual setups" PR! 

When I checked the link in the main README tonight, I realized it was not working because the 'c' was not capitalized. So I quickly set up this PR.

I apologize for this minor error and for letting it get into main.