### PR TITLE
match new lerobot angles

### DIFF
--- a/Simulation/SO100/so100.urdf
+++ b/Simulation/SO100/so100.urdf
@@ -182,7 +182,7 @@
     <parent link="base"/>
     <child link="shoulder"/>
     <origin xyz="0 -0.0452 0.0165" rpy="1.57079 0 0"/>
-    <axis xyz="0 1 0"/>
+    <axis xyz="0 -1 0"/>
     <limit lower="-2" upper="2" effort="35" velocity="1"/>
   </joint>
 
@@ -201,9 +201,9 @@
   <joint name="2" type="revolute">
     <parent link="shoulder"/>
     <child link="upper_arm"/>
-    <origin xyz="0 0.1025 0.0306" rpy="-1.8 0 0"/>
+    <origin xyz="0 0.1025 0.0306" rpy="-0.05 0 0"/>
     <axis xyz="1 0 0"/>
-    <limit lower="0" upper="3.5" effort="35" velocity="1"/>
+    <limit lower="-1.75" upper="1.75" effort="35" velocity="1"/>
   </joint>
 
   <transmission name="2_trans">
@@ -221,9 +221,9 @@
   <joint name="3" type="revolute">
     <parent link="upper_arm"/>
     <child link="lower_arm"/>
-    <origin xyz="0 0.11257 0.028" rpy="1.57079 0 0"/>
+    <origin xyz="0 0.11257 0.028" rpy="0 0 0"/>
     <axis xyz="1 0 0"/>
-    <limit lower="-3.14158" upper="0" effort="35" velocity="1"/>
+    <limit lower="-1.57079" upper="1.57079" effort="35" velocity="1"/>
   </joint>
 
   <transmission name="3_trans">
@@ -241,9 +241,9 @@
   <joint name="4" type="revolute">
     <parent link="lower_arm"/>
     <child link="wrist"/>
-    <origin xyz="0 0.0052 0.1349" rpy="-1 0 0"/>
+    <origin xyz="0 0.0052 0.1349" rpy="-1.5236 0 0"/>
     <axis xyz="1 0 0"/>
-    <limit lower="-2.5" upper="1.2" effort="35" velocity="1"/>
+    <limit lower="-1.9764" upper="1.7236" effort="35" velocity="1"/>
   </joint>
 
   <transmission name="4_trans">
@@ -281,9 +281,9 @@
   <joint name="6" type="revolute">
     <parent link="gripper"/>
     <child link="jaw"/>
-    <origin xyz="-0.0202 -0.0244 0" rpy="0 3.14158 0"/>
+    <origin xyz="-0.0202 -0.0244 0" rpy="0 3.14158 -0.9"/>
     <axis xyz="0 0 1"/>
-    <limit lower="-0.2" upper="2.0" effort="35" velocity="1"/>
+    <limit lower="-1.1" upper="1.1" effort="35" velocity="1"/>
   </joint>
 
   <transmission name="6_trans">


### PR DESCRIPTION
Here I've matched the SO100 URDF to align with the new coordinates that the latest lerobot package produces, as described in https://github.com/TheRobotStudio/SO-ARM100/issues/94
The joints now have their 0 position in the middle of the joint ranges.