### PR TITLE
Fix Mujoco attributes

### DIFF
--- a/Simulation/SO101/so101_new_calib.xml
+++ b/Simulation/SO101/so101_new_calib.xml
@@ -5,8 +5,8 @@
   <compiler angle="radian" meshdir="assets" autolimits="true"/>
   <default>
     <default class="so101_new_calib">
-      <joint frictionloss="0.1" armature="0.005"/>
-      <position kp="50" dampratio="1"/>
+      <joint damping="1" frictionloss="0.1" armature="0.005"/>
+      <position kp="50"/>
       <default class="visual">
         <geom type="mesh" contype="0" conaffinity="0" group="2"/>
       </default>
@@ -20,7 +20,7 @@
     <default class="sts3215">
       <geom contype="0" conaffinity="0"/>
       <joint damping="0.60" frictionloss="0.052" armature="0.028"/>
-      <position kp="17.8" kv="0.0" forcerange="-3.35 3.35"/>
+      <position kp="17.8"/>
     </default>
     <default class="backlash">
       <!-- +/- 0.5° of backlash -->
@@ -149,12 +149,12 @@
     <material name="moving_jaw_so101_v1_material" rgba="0.964706 0.964706 0.952941 1"/>
   </asset>
   <actuator>
-    <position class="sts3215" name="1" joint="1" inheritrange="1"/>
-    <position class="sts3215" name="2" joint="2" inheritrange="1"/>
-    <position class="sts3215" name="3" joint="3" inheritrange="1"/>
-    <position class="sts3215" name="4" joint="4" inheritrange="1"/>
-    <position class="sts3215" name="5" joint="5" inheritrange="1"/>
-    <position class="sts3215" name="6" joint="6" inheritrange="1"/>
+    <position class="sts3215" name="1" joint="1" forcerange="-3.35 3.35"/>
+    <position class="sts3215" name="2" joint="2" forcerange="-3.35 3.35"/>
+    <position class="sts3215" name="3" joint="3" forcerange="-3.35 3.35"/>
+    <position class="sts3215" name="4" joint="4" forcerange="-3.35 3.35"/>
+    <position class="sts3215" name="5" joint="5" forcerange="-3.35 3.35"/>
+    <position class="sts3215" name="6" joint="6" forcerange="-3.35 3.35"/>
   </actuator>
   <equality/>
 </mujoco>

--- a/Simulation/SO101/so101_old_calib.xml
+++ b/Simulation/SO101/so101_old_calib.xml
@@ -5,8 +5,8 @@
   <compiler angle="radian" meshdir="assets" autolimits="true"/>
   <default>
     <default class="so101_old_calib">
-      <joint frictionloss="0.1" armature="0.005"/>
-      <position kp="50" dampratio="1"/>
+      <joint damping="1" frictionloss="0.1" armature="0.005"/>
+      <position kp="50"/>
       <default class="visual">
         <geom type="mesh" contype="0" conaffinity="0" group="2"/>
       </default>
@@ -20,7 +20,7 @@
     <default class="sts3215">
       <geom contype="0" conaffinity="0"/>
       <joint damping="0.60" frictionloss="0.052" armature="0.028"/>
-      <position kp="17.8" kv="0.0" forcerange="-3.35 3.35"/>
+      <position kp="17.8"/>
     </default>
     <default class="backlash">
       <!-- +/- 0.5° of backlash -->
@@ -149,12 +149,12 @@
     <material name="moving_jaw_so101_v1_material" rgba="0.964706 0.964706 0.952941 1"/>
   </asset>
   <actuator>
-    <position class="sts3215" name="1" joint="1" inheritrange="1"/>
-    <position class="sts3215" name="2" joint="2" inheritrange="1"/>
-    <position class="sts3215" name="3" joint="3" inheritrange="1"/>
-    <position class="sts3215" name="4" joint="4" inheritrange="1"/>
-    <position class="sts3215" name="5" joint="5" inheritrange="1"/>
-    <position class="sts3215" name="6" joint="6" inheritrange="1"/>
+    <position class="sts3215" name="1" joint="1" forcerange="-3.35 3.35"/>
+    <position class="sts3215" name="2" joint="2" forcerange="-3.35 3.35"/>
+    <position class="sts3215" name="3" joint="3" forcerange="-3.35 3.35"/>
+    <position class="sts3215" name="4" joint="4" forcerange="-3.35 3.35"/>
+    <position class="sts3215" name="5" joint="5" forcerange="-3.35 3.35"/>
+    <position class="sts3215" name="6" joint="6" forcerange="-3.35 3.35"/>
   </actuator>
   <equality/>
 </mujoco>


### PR DESCRIPTION
There are a few incorrect mujoco attributes in the XML files generated from the CAD-to-Mujoco script. Might be due to the script not being updated. 

With the incorrect Mujoco files, if they are loaded into the Mujoco viewer app directly, Mujoco ignores the errors, but when using their python SDK, these issues aren't ignored and show up as errors. 

After these fixes, the XML files work in both ways - via the viewer + via the SDK. 