### PR TITLE
Updated the new so101 calibration urdf with fixed direction and frame

### DIFF
--- a/Simulation/SO101/so101_new_calib.urdf
+++ b/Simulation/SO101/so101_new_calib.urdf
@@ -1,81 +1,94 @@
-<?xml version='1.0' encoding='utf-8'?>
+<?xml version="1.0" ?>
 <!-- Generated using onshape-to-robot -->
 <!-- Onshape https://cad.onshape.com/documents/7715cc284bb430fe6dab4ffd/w/4fd0791b683777b02f8d975a/e/826c553ede3b7592eb9ca800 -->
 <robot name="so101_new_calib">
-
-  <!-- Materials -->
-  <material name="3d_printed">
-    <color rgba="1.0 0.82 0.12 1.0"/>
-  </material>
-  <material name="sts3215">
-    <color rgba="0.1 0.1 0.1 1.0"/>
-  </material>
-
   <!-- Link base -->
   <link name="base">
     <inertial>
-      <origin xyz="0.020739 0.00204287 0.065966" rpy="0 0 0"/>
+      <origin xyz="-0.14932 -0.16812 0.065966" rpy="0 0 0"/>
       <mass value="0.147"/>
-      <inertia ixx="0.000136117" ixy="4.59787e-07" ixz="9.75275e-08" iyy="0.000114686" iyz="-4.97151e-06" izz="0.000130364"/>
+      <inertia ixx="0.000114686" ixy="-4.59787e-07" ixz="4.97151e-06" iyy="0.000136117" iyz="9.75275e-08" izz="0.000130364"/>
     </inertial>
     <!-- Part base_motor_holder_so101_v1 -->
     <visual>
-      <origin xyz="0.0206915 0.0221255 0.0300817" rpy="1.5708 -1.23909e-16 2.33147e-15"/>
+      <origin xyz="-0.169402 -0.168167 0.0300817" rpy="1.5708 -1.67685e-15 1.5708"/>
       <geometry>
-        <mesh filename="assets/base_motor_holder_so101_v1.stl"/>
+        <mesh filename="package://assets/base_motor_holder_so101_v1.stl"/>
       </geometry>
-      <material name="3d_printed"/>
+      <material name="base_motor_holder_so101_v1_material">
+        <color rgba="0.964706 0.964706 0.952941 1.0"/>
+      </material>
     </visual>
     <collision>
-      <origin xyz="0.0206915 0.0221255 0.0300817" rpy="1.5708 -1.23909e-16 2.33147e-15"/>
+      <origin xyz="-0.169402 -0.168167 0.0300817" rpy="1.5708 -1.67685e-15 1.5708"/>
       <geometry>
-        <mesh filename="assets/base_motor_holder_so101_v1.stl"/>
+        <mesh filename="package://assets/base_motor_holder_so101_v1.stl"/>
       </geometry>
     </collision>
     <!-- Part base_so101_v2 -->
     <visual>
-      <origin xyz="0.0207909 0.0221255 0.0300817" rpy="1.5708 -0 0"/>
+      <origin xyz="-0.169402 -0.168068 0.0300817" rpy="1.5708 -1.6144e-15 1.5708"/>
       <geometry>
-        <mesh filename="assets/base_so101_v2.stl"/>
+        <mesh filename="package://assets/base_so101_v2.stl"/>
       </geometry>
-      <material name="3d_printed"/>
+      <material name="base_so101_v2_material">
+        <color rgba="0.964706 0.964706 0.952941 1.0"/>
+      </material>
     </visual>
     <collision>
-      <origin xyz="0.0207909 0.0221255 0.0300817" rpy="1.5708 -0 0"/>
+      <origin xyz="-0.169402 -0.168068 0.0300817" rpy="1.5708 -1.6144e-15 1.5708"/>
       <geometry>
-        <mesh filename="assets/base_so101_v2.stl"/>
+        <mesh filename="package://assets/base_so101_v2.stl"/>
       </geometry>
     </collision>
     <!-- Part sts3215_03a_v1 -->
     <visual>
-      <origin xyz="0.0207909 -0.0105745 0.0761817" rpy="-2.20282e-15 2.77556e-17 -1.5708"/>
+      <origin xyz="-0.136702 -0.168068 0.0761817" rpy="-8.21148e-16 7.84513e-18 1.249e-15"/>
       <geometry>
-        <mesh filename="assets/sts3215_03a_v1.stl"/>
+        <mesh filename="package://assets/sts3215_03a_v1.stl"/>
       </geometry>
-      <material name="sts3215"/>
+      <material name="sts3215_03a_v1_material">
+        <color rgba="0.627451 0.627451 0.627451 1.0"/>
+      </material>
     </visual>
     <collision>
-      <origin xyz="0.0207909 -0.0105745 0.0761817" rpy="-2.20282e-15 2.77556e-17 -1.5708"/>
+      <origin xyz="-0.136702 -0.168068 0.0761817" rpy="-8.21148e-16 7.84513e-18 1.249e-15"/>
       <geometry>
-        <mesh filename="assets/sts3215_03a_v1.stl"/>
+        <mesh filename="package://assets/sts3215_03a_v1.stl"/>
       </geometry>
     </collision>
     <!-- Part waveshare_mounting_plate_so101_v2 -->
     <visual>
-      <origin xyz="0.0205915 0.0467435 0.0798817" rpy="1.5708 -1.21716e-14 2.33147e-15"/>
+      <origin xyz="-0.19402 -0.168267 0.0798817" rpy="1.5708 -1.35493e-14 1.5708"/>
       <geometry>
-        <mesh filename="assets/waveshare_mounting_plate_so101_v2.stl"/>
+        <mesh filename="package://assets/waveshare_mounting_plate_so101_v2.stl"/>
       </geometry>
-      <material name="3d_printed"/>
+      <material name="waveshare_mounting_plate_so101_v2_material">
+        <color rgba="0.964706 0.964706 0.952941 1.0"/>
+      </material>
     </visual>
     <collision>
-      <origin xyz="0.0205915 0.0467435 0.0798817" rpy="1.5708 -1.21716e-14 2.33147e-15"/>
+      <origin xyz="-0.19402 -0.168267 0.0798817" rpy="1.5708 -1.35493e-14 1.5708"/>
       <geometry>
-        <mesh filename="assets/waveshare_mounting_plate_so101_v2.stl"/>
+        <mesh filename="package://assets/waveshare_mounting_plate_so101_v2.stl"/>
       </geometry>
     </collision>
   </link>
-
+  <!-- Frame baseframe (dummy link + fixed joint) -->
+  <link name="baseframe">
+    <origin xyz="0 0 0" rpy="0 -0 0"/>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1e-9"/>
+      <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+    </inertial>
+  </link>
+  <joint name="baseframe_frame" type="fixed">
+    <origin xyz="-0.163038 -0.168068 0.0324817" rpy="1.6144e-15 7.84513e-18 1.33799e-15"/>
+    <parent link="base"/>
+    <child link="baseframe"/>
+    <axis xyz="0 0 0"/>
+  </joint>
   <!-- Link shoulder -->
   <link name="shoulder">
     <inertial>
@@ -87,46 +100,51 @@
     <visual>
       <origin xyz="-0.0303992 0.000422241 -0.0417" rpy="1.5708 1.5708 0"/>
       <geometry>
-        <mesh filename="assets/sts3215_03a_v1.stl"/>
+        <mesh filename="package://assets/sts3215_03a_v1.stl"/>
       </geometry>
-      <material name="sts3215"/>
+      <material name="sts3215_03a_v1_2_material">
+        <color rgba="0.627451 0.627451 0.627451 1.0"/>
+      </material>
     </visual>
     <collision>
       <origin xyz="-0.0303992 0.000422241 -0.0417" rpy="1.5708 1.5708 0"/>
       <geometry>
-        <mesh filename="assets/sts3215_03a_v1.stl"/>
+        <mesh filename="package://assets/sts3215_03a_v1.stl"/>
       </geometry>
     </collision>
     <!-- Part motor_holder_so101_base_v1 -->
     <visual>
       <origin xyz="-0.0675992 -0.000177759 0.0158499" rpy="1.5708 -1.5708 0"/>
       <geometry>
-        <mesh filename="assets/motor_holder_so101_base_v1.stl"/>
+        <mesh filename="package://assets/motor_holder_so101_base_v1.stl"/>
       </geometry>
-      <material name="3d_printed"/>
+      <material name="motor_holder_so101_base_v1_material">
+        <color rgba="0.964706 0.964706 0.952941 1.0"/>
+      </material>
     </visual>
     <collision>
       <origin xyz="-0.0675992 -0.000177759 0.0158499" rpy="1.5708 -1.5708 0"/>
       <geometry>
-        <mesh filename="assets/motor_holder_so101_base_v1.stl"/>
+        <mesh filename="package://assets/motor_holder_so101_base_v1.stl"/>
       </geometry>
     </collision>
     <!-- Part rotation_pitch_so101_v1 -->
     <visual>
-      <origin xyz="0.0122008 2.22413e-05 0.0464" rpy="-1.5708 -0 0"/>
+      <origin xyz="0.0122008 2.22413e-05 0.0464" rpy="-1.5708 2.35221e-33 0"/>
       <geometry>
-        <mesh filename="assets/rotation_pitch_so101_v1.stl"/>
+        <mesh filename="package://assets/rotation_pitch_so101_v1.stl"/>
       </geometry>
-      <material name="3d_printed"/>
+      <material name="rotation_pitch_so101_v1_material">
+        <color rgba="0.964706 0.964706 0.952941 1.0"/>
+      </material>
     </visual>
     <collision>
-      <origin xyz="0.0122008 2.22413e-05 0.0464" rpy="-1.5708 -0 0"/>
+      <origin xyz="0.0122008 2.22413e-05 0.0464" rpy="-1.5708 2.35221e-33 0"/>
       <geometry>
-        <mesh filename="assets/rotation_pitch_so101_v1.stl"/>
+        <mesh filename="package://assets/rotation_pitch_so101_v1.stl"/>
       </geometry>
     </collision>
   </link>
-
   <!-- Link upper_arm -->
   <link name="upper_arm">
     <inertial>
@@ -136,34 +154,37 @@
     </inertial>
     <!-- Part sts3215_03a_v1_3 -->
     <visual>
-      <origin xyz="-0.11257 -0.0155 0.0187" rpy="-3.14159 -6.8695e-16 -1.5708"/>
+      <origin xyz="-0.11257 -0.0155 0.0187" rpy="-3.14159 -5.27356e-16 -1.5708"/>
       <geometry>
-        <mesh filename="assets/sts3215_03a_v1.stl"/>
+        <mesh filename="package://assets/sts3215_03a_v1.stl"/>
       </geometry>
-      <material name="sts3215"/>
+      <material name="sts3215_03a_v1_3_material">
+        <color rgba="0.627451 0.627451 0.627451 1.0"/>
+      </material>
     </visual>
     <collision>
-      <origin xyz="-0.11257 -0.0155 0.0187" rpy="-3.14159 -6.8695e-16 -1.5708"/>
+      <origin xyz="-0.11257 -0.0155 0.0187" rpy="-3.14159 -5.27356e-16 -1.5708"/>
       <geometry>
-        <mesh filename="assets/sts3215_03a_v1.stl"/>
+        <mesh filename="package://assets/sts3215_03a_v1.stl"/>
       </geometry>
     </collision>
     <!-- Part upper_arm_so101_v1 -->
     <visual>
-      <origin xyz="-0.065085 0.012 0.0182" rpy="3.14159 -9.35612e-32 0"/>
+      <origin xyz="-0.065085 0.012 0.0182" rpy="3.14159 -0 -1.30911e-30"/>
       <geometry>
-        <mesh filename="assets/upper_arm_so101_v1.stl"/>
+        <mesh filename="package://assets/upper_arm_so101_v1.stl"/>
       </geometry>
-      <material name="3d_printed"/>
+      <material name="upper_arm_so101_v1_material">
+        <color rgba="0.964706 0.964706 0.952941 1.0"/>
+      </material>
     </visual>
     <collision>
-      <origin xyz="-0.065085 0.012 0.0182" rpy="3.14159 -9.35612e-32 0"/>
+      <origin xyz="-0.065085 0.012 0.0182" rpy="3.14159 -0 -1.30911e-30"/>
       <geometry>
-        <mesh filename="assets/upper_arm_so101_v1.stl"/>
+        <mesh filename="package://assets/upper_arm_so101_v1.stl"/>
       </geometry>
     </collision>
   </link>
-
   <!-- Link lower_arm -->
   <link name="lower_arm">
     <inertial>
@@ -173,48 +194,53 @@
     </inertial>
     <!-- Part under_arm_so101_v1 -->
     <visual>
-      <origin xyz="-0.0648499 -0.032 0.0182" rpy="-3.14159 -0 3.9443e-31"/>
+      <origin xyz="-0.0648499 -0.032 0.0182" rpy="3.14159 -0 6.67202e-31"/>
       <geometry>
-        <mesh filename="assets/under_arm_so101_v1.stl"/>
+        <mesh filename="package://assets/under_arm_so101_v1.stl"/>
       </geometry>
-      <material name="3d_printed"/>
+      <material name="under_arm_so101_v1_material">
+        <color rgba="0.964706 0.964706 0.952941 1.0"/>
+      </material>
     </visual>
     <collision>
-      <origin xyz="-0.0648499 -0.032 0.0182" rpy="-3.14159 -0 3.9443e-31"/>
+      <origin xyz="-0.0648499 -0.032 0.0182" rpy="3.14159 -0 6.67202e-31"/>
       <geometry>
-        <mesh filename="assets/under_arm_so101_v1.stl"/>
+        <mesh filename="package://assets/under_arm_so101_v1.stl"/>
       </geometry>
     </collision>
     <!-- Part motor_holder_so101_wrist_v1 -->
     <visual>
-      <origin xyz="-0.0648499 -0.032 0.018" rpy="-3.14159 4.73317e-30 7.88861e-31"/>
+      <origin xyz="-0.0648499 -0.032 0.018" rpy="-3.14159 -2.55351e-15 -2.56146e-31"/>
       <geometry>
-        <mesh filename="assets/motor_holder_so101_wrist_v1.stl"/>
+        <mesh filename="package://assets/motor_holder_so101_wrist_v1.stl"/>
       </geometry>
-      <material name="3d_printed"/>
+      <material name="motor_holder_so101_wrist_v1_material">
+        <color rgba="0.964706 0.964706 0.952941 1.0"/>
+      </material>
     </visual>
     <collision>
-      <origin xyz="-0.0648499 -0.032 0.018" rpy="-3.14159 4.73317e-30 7.88861e-31"/>
+      <origin xyz="-0.0648499 -0.032 0.018" rpy="-3.14159 -2.55351e-15 -2.56146e-31"/>
       <geometry>
-        <mesh filename="assets/motor_holder_so101_wrist_v1.stl"/>
+        <mesh filename="package://assets/motor_holder_so101_wrist_v1.stl"/>
       </geometry>
     </collision>
     <!-- Part sts3215_03a_v1_4 -->
     <visual>
-      <origin xyz="-0.1224 0.0052 0.0187" rpy="-3.14159 -3.58047e-15 -3.14159"/>
+      <origin xyz="-0.1224 0.0052 0.0187" rpy="-3.14159 -7.88861e-31 -3.14159"/>
       <geometry>
-        <mesh filename="assets/sts3215_03a_v1.stl"/>
+        <mesh filename="package://assets/sts3215_03a_v1.stl"/>
       </geometry>
-      <material name="sts3215"/>
+      <material name="sts3215_03a_v1_4_material">
+        <color rgba="0.627451 0.627451 0.627451 1.0"/>
+      </material>
     </visual>
     <collision>
-      <origin xyz="-0.1224 0.0052 0.0187" rpy="-3.14159 -3.58047e-15 -3.14159"/>
+      <origin xyz="-0.1224 0.0052 0.0187" rpy="-3.14159 -7.88861e-31 -3.14159"/>
       <geometry>
-        <mesh filename="assets/sts3215_03a_v1.stl"/>
+        <mesh filename="package://assets/sts3215_03a_v1.stl"/>
       </geometry>
     </collision>
   </link>
-
   <!-- Link wrist -->
   <link name="wrist">
     <inertial>
@@ -226,32 +252,35 @@
     <visual>
       <origin xyz="5.55112e-17 -0.0424 0.0306" rpy="1.5708 1.5708 0"/>
       <geometry>
-        <mesh filename="assets/sts3215_03a_no_horn_v1.stl"/>
+        <mesh filename="package://assets/sts3215_03a_no_horn_v1.stl"/>
       </geometry>
-      <material name="sts3215"/>
+      <material name="sts3215_03a_no_horn_v1_material">
+        <color rgba="0.627451 0.627451 0.627451 1.0"/>
+      </material>
     </visual>
     <collision>
       <origin xyz="5.55112e-17 -0.0424 0.0306" rpy="1.5708 1.5708 0"/>
       <geometry>
-        <mesh filename="assets/sts3215_03a_no_horn_v1.stl"/>
+        <mesh filename="package://assets/sts3215_03a_no_horn_v1.stl"/>
       </geometry>
     </collision>
     <!-- Part wrist_roll_pitch_so101_v2 -->
     <visual>
       <origin xyz="0 -0.028 0.0181" rpy="-1.5708 -1.5708 0"/>
       <geometry>
-        <mesh filename="assets/wrist_roll_pitch_so101_v2.stl"/>
+        <mesh filename="package://assets/wrist_roll_pitch_so101_v2.stl"/>
       </geometry>
-      <material name="3d_printed"/>
+      <material name="wrist_roll_pitch_so101_v2_material">
+        <color rgba="0.964706 0.964706 0.952941 1.0"/>
+      </material>
     </visual>
     <collision>
       <origin xyz="0 -0.028 0.0181" rpy="-1.5708 -1.5708 0"/>
       <geometry>
-        <mesh filename="assets/wrist_roll_pitch_so101_v2.stl"/>
+        <mesh filename="package://assets/wrist_roll_pitch_so101_v2.stl"/>
       </geometry>
     </collision>
   </link>
-
   <!-- Link gripper -->
   <link name="gripper">
     <inertial>
@@ -261,36 +290,54 @@
     </inertial>
     <!-- Part sts3215_03a_v1_5 -->
     <visual>
-      <origin xyz="0.0077 0.0001 -0.0234" rpy="-1.5708 -5.55112e-17 -1.38213e-14"/>
+      <origin xyz="0.0077 0.0001 -0.0234" rpy="-1.5708 -5.19179e-17 -1.66533e-16"/>
       <geometry>
-        <mesh filename="assets/sts3215_03a_v1.stl"/>
+        <mesh filename="package://assets/sts3215_03a_v1.stl"/>
       </geometry>
-      <material name="sts3215"/>
+      <material name="sts3215_03a_v1_5_material">
+        <color rgba="0.627451 0.627451 0.627451 1.0"/>
+      </material>
     </visual>
     <collision>
-      <origin xyz="0.0077 0.0001 -0.0234" rpy="-1.5708 -5.55112e-17 -1.38213e-14"/>
+      <origin xyz="0.0077 0.0001 -0.0234" rpy="-1.5708 -5.19179e-17 -1.66533e-16"/>
       <geometry>
-        <mesh filename="assets/sts3215_03a_v1.stl"/>
+        <mesh filename="package://assets/sts3215_03a_v1.stl"/>
       </geometry>
     </collision>
     <!-- Part wrist_roll_follower_so101_v1 -->
     <visual>
-      <origin xyz="5.55112e-17 -0.000218214 0.000949706" rpy="-3.14159 -5.55112e-17 -9.17912e-24"/>
+      <origin xyz="0 -0.000218214 0.000949706" rpy="-3.14159 -5.55112e-17 0"/>
       <geometry>
-        <mesh filename="assets/wrist_roll_follower_so101_v1.stl"/>
+        <mesh filename="package://assets/wrist_roll_follower_so101_v1.stl"/>
       </geometry>
-      <material name="3d_printed"/>
+      <material name="wrist_roll_follower_so101_v1_material">
+        <color rgba="0.964706 0.964706 0.952941 1.0"/>
+      </material>
     </visual>
     <collision>
-      <origin xyz="5.55112e-17 -0.000218214 0.000949706" rpy="-3.14159 -5.55112e-17 -9.17912e-24"/>
+      <origin xyz="0 -0.000218214 0.000949706" rpy="-3.14159 -5.55112e-17 0"/>
       <geometry>
-        <mesh filename="assets/wrist_roll_follower_so101_v1.stl"/>
+        <mesh filename="package://assets/wrist_roll_follower_so101_v1.stl"/>
       </geometry>
     </collision>
   </link>
-
-  <!-- Link jaw -->
-  <link name="jaw">
+  <!-- Frame gripperframe (dummy link + fixed joint) -->
+  <link name="gripperframe">
+    <origin xyz="0 0 0" rpy="0 -0 0"/>
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="1e-9"/>
+      <inertia ixx="0" ixy="0" ixz="0" iyy="0" iyz="0" izz="0"/>
+    </inertial>
+  </link>
+  <joint name="gripperframe_frame" type="fixed">
+    <origin xyz="-0.0079 -0.000218121 -0.0981274" rpy="-0 1.5708 0"/>
+    <parent link="gripper"/>
+    <child link="gripperframe"/>
+    <axis xyz="0 0 0"/>
+  </joint>
+  <!-- Link moving_jaw_so101_v1 -->
+  <link name="moving_jaw_so101_v1">
     <inertial>
       <origin xyz="-0.00157495 -0.0300244 0.0192755" rpy="0 0 0"/>
       <mass value="0.012"/>
@@ -298,100 +345,53 @@
     </inertial>
     <!-- Part moving_jaw_so101_v1 -->
     <visual>
-      <origin xyz="-5.55112e-17 -1.94746e-17 0.0189" rpy="9.53145e-17 -4.66093e-24 0"/>
+      <origin xyz="-5.55112e-17 0 0.0189" rpy="9.53145e-17 6.93889e-18 1.24077e-24"/>
       <geometry>
-        <mesh filename="assets/moving_jaw_so101_v1.stl"/>
+        <mesh filename="package://assets/moving_jaw_so101_v1.stl"/>
       </geometry>
-      <material name="3d_printed"/>
+      <material name="moving_jaw_so101_v1_material">
+        <color rgba="0.964706 0.964706 0.952941 1.0"/>
+      </material>
     </visual>
     <collision>
-      <origin xyz="-5.55112e-17 -1.94746e-17 0.0189" rpy="9.53145e-17 -4.66093e-24 0"/>
+      <origin xyz="-5.55112e-17 0 0.0189" rpy="9.53145e-17 6.93889e-18 1.24077e-24"/>
       <geometry>
-        <mesh filename="assets/moving_jaw_so101_v1.stl"/>
+        <mesh filename="package://assets/moving_jaw_so101_v1.stl"/>
       </geometry>
     </collision>
   </link>
-
-  <!-- Joint from gripper to jaw -->
+  <!-- Joint from gripper to moving_jaw_so101_v1 -->
   <joint name="6" type="revolute">
-    <origin xyz="0.0202 0.0188 -0.0234" rpy="1.5708 -5.14108e-17 -1.38655e-14"/>
+    <origin xyz="0.0202 0.0188 -0.0234" rpy="1.5708 -5.24284e-08 -1.41553e-15"/>
     <parent link="gripper"/>
-    <child link="jaw"/>
+    <child link="moving_jaw_so101_v1"/>
     <axis xyz="0 0 1"/>
     <limit effort="10" velocity="10" lower="-0.174533" upper="1.74533"/>
   </joint>
-
-  <transmission name="6_trans">
-    <type>transmission_interface/SimpleTransmission</type>
-    <joint name="6">
-      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-    </joint>
-    <actuator name="motor6">
-      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-      <mechanicalReduction>1</mechanicalReduction>
-    </actuator>
-  </transmission>
-
   <!-- Joint from wrist to gripper -->
   <joint name="5" type="revolute">
-    <origin xyz="0 -0.0611 0.0181" rpy="1.5708 -9.38083e-08 3.14159"/>
+    <origin xyz="2.77556e-16 -0.0611 0.0181" rpy="1.5708 0.0486795 3.14159"/>
     <parent link="wrist"/>
     <child link="gripper"/>
     <axis xyz="0 0 1"/>
-    <limit effort="10" velocity="10" lower="-2.79253" upper="2.79253"/>
+    <limit effort="10" velocity="10" lower="-2.74385" upper="2.84121"/>
   </joint>
-
-  <transmission name="5_trans">
-    <type>transmission_interface/SimpleTransmission</type>
-    <joint name="5">
-      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-    </joint>
-    <actuator name="motor5">
-      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-      <mechanicalReduction>1</mechanicalReduction>
-    </actuator>
-  </transmission>
-
   <!-- Joint from lower_arm to wrist -->
   <joint name="4" type="revolute">
-    <origin xyz="-0.1349 0.0052 1.65232e-16" rpy="3.2474e-15 2.86219e-15 -1.5708"/>
+    <origin xyz="-0.1349 0.0052 8.44651e-17" rpy="4.02456e-15 8.67362e-16 -1.5708"/>
     <parent link="lower_arm"/>
     <child link="wrist"/>
     <axis xyz="0 0 1"/>
     <limit effort="10" velocity="10" lower="-1.65806" upper="1.65806"/>
   </joint>
-
-  <transmission name="4_trans">
-    <type>transmission_interface/SimpleTransmission</type>
-    <joint name="4">
-      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-    </joint>
-    <actuator name="motor4">
-      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-      <mechanicalReduction>1</mechanicalReduction>
-    </actuator>
-  </transmission>
-
   <!-- Joint from upper_arm to lower_arm -->
   <joint name="3" type="revolute">
-    <origin xyz="-0.11257 -0.028 2.46331e-16" rpy="-1.22818e-15 5.75928e-16 1.5708"/>
+    <origin xyz="-0.11257 -0.028 2.09886e-16" rpy="-3.63608e-16 8.74301e-16 1.5708"/>
     <parent link="upper_arm"/>
     <child link="lower_arm"/>
     <axis xyz="0 0 1"/>
     <limit effort="10" velocity="10" lower="-1.74533" upper="1.5708"/>
   </joint>
-
-  <transmission name="3_trans">
-    <type>transmission_interface/SimpleTransmission</type>
-    <joint name="3">
-      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-    </joint>
-    <actuator name="motor3">
-      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-      <mechanicalReduction>1</mechanicalReduction>
-    </actuator>
-  </transmission>
-
   <!-- Joint from shoulder to upper_arm -->
   <joint name="2" type="revolute">
     <origin xyz="-0.0303992 -0.0182778 -0.0542" rpy="-1.5708 -1.5708 0"/>
@@ -400,36 +400,12 @@
     <axis xyz="0 0 1"/>
     <limit effort="10" velocity="10" lower="-1.74533" upper="1.74533"/>
   </joint>
-
-  <transmission name="2_trans">
-    <type>transmission_interface/SimpleTransmission</type>
-    <joint name="2">
-      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-    </joint>
-    <actuator name="motor2">
-      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-      <mechanicalReduction>1</mechanicalReduction>
-    </actuator>
-  </transmission>
-
   <!-- Joint from base to shoulder -->
   <joint name="1" type="revolute">
-    <origin xyz="0.0207909 -0.0230745 0.0948817" rpy="-3.14159 6.03684e-16 1.5708"/>
+    <origin xyz="-0.124202 -0.168068 0.0948817" rpy="3.14159 4.18253e-17 -3.14159"/>
     <parent link="base"/>
     <child link="shoulder"/>
     <axis xyz="0 0 1"/>
     <limit effort="10" velocity="10" lower="-1.91986" upper="1.91986"/>
   </joint>
-
-  <transmission name="1_trans">
-    <type>transmission_interface/SimpleTransmission</type>
-    <joint name="1">
-      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-    </joint>
-    <actuator name="motor1">
-      <hardwareInterface>hardware_interface/PositionJointInterface</hardwareInterface>
-      <mechanicalReduction>1</mechanicalReduction>
-    </actuator>
-  </transmission>
-
 </robot>

--- a/Simulation/SO101/so101_new_calib.xml
+++ b/Simulation/SO101/so101_new_calib.xml
@@ -20,7 +20,8 @@
     <default class="sts3215">
       <geom contype="0" conaffinity="0"/>
       <joint damping="0.60" frictionloss="0.052" armature="0.028"/>
-      <position kp="17.8" kv="0.0" forcerange="-3.35 3.35"/>
+      <!-- For lerobot this are not exactly the motor params as the Kp and Kd not map 1-to-1 thus motor idendification with lerobot Kp=16 and Kd=32 should actually be done -->
+      <position kp="17.8" kv="1.0" forcerange="-3.35 3.35"/>
     </default>
     <default class="backlash">
       <!-- +/- 0.5° of backlash -->
@@ -30,19 +31,19 @@
   <worldbody>
     <!-- Link base -->
     <body name="base" pos="0 0 0" quat="1 0 0 0" childclass="so101_new_calib">
-      <inertial pos="0.020739 0.00204287 0.065966" mass="0.147" fullinertia="0.000136117 0.000114686 0.000130364 4.59787e-07 9.75275e-08 -4.97151e-06"/>
+      <inertial pos="-0.14932 -0.16812 0.065966" mass="0.147" fullinertia="0.000114686 0.000136117 0.000130364 -4.59787e-07 4.97151e-06 9.75275e-08"/>
       <!-- Part base_motor_holder_so101_v1 -->
-      <geom type="mesh" class="visual" pos="0.0206915 0.0221255 0.0300817" quat="0.707107 0.707107 7.85046e-16 8.68107e-16" mesh="base_motor_holder_so101_v1" material="base_motor_holder_so101_v1_material"/>
+      <geom type="mesh" class="visual" pos="-0.169402 -0.168167 0.0300817" quat="0.5 0.5 0.5 0.5" mesh="base_motor_holder_so101_v1" material="base_motor_holder_so101_v1_material"/>
       <!-- Part base_so101_v2 -->
-      <geom type="mesh" class="visual" pos="0.0207909 0.0221255 0.0300817" quat="0.707107 0.707107 -0 -0" mesh="base_so101_v2" material="base_so101_v2_material"/>
+      <geom type="mesh" class="visual" pos="-0.169402 -0.168068 0.0300817" quat="0.5 0.5 0.5 0.5" mesh="base_so101_v2" material="base_so101_v2_material"/>
       <!-- Part sts3215_03a_v1 -->
-      <geom type="mesh" class="visual" pos="0.0207909 -0.0105745 0.0761817" quat="0.707107 -7.69919e-16 8.95976e-16 -0.707107" mesh="sts3215_03a_v1" material="sts3215_03a_v1_material"/>
+      <geom type="mesh" class="visual" pos="-0.136702 -0.168068 0.0761817" quat="1 -2.85511e-16 -9.64433e-17 6.12908e-16" mesh="sts3215_03a_v1" material="sts3215_03a_v1_material"/>
       <!-- Part waveshare_mounting_plate_so101_v2 -->
-      <geom type="mesh" class="visual" pos="0.0205915 0.0467435 0.0798817" quat="0.707107 0.707107 -3.34318e-15 5.1276e-15" mesh="waveshare_mounting_plate_so101_v2" material="waveshare_mounting_plate_so101_v2_material"/>
-      <!-- Frame base -->
-      <site group="3" name="base" pos="0.020791 0.0157608 0.0324817" quat="0 1 0 0"/>
+      <geom type="mesh" class="visual" pos="-0.19402 -0.168267 0.0798817" quat="0.5 0.5 0.5 0.5" mesh="waveshare_mounting_plate_so101_v2" material="waveshare_mounting_plate_so101_v2_material"/>
+      <!-- Frame baseframe -->
+      <site group="3" name="baseframe" pos="-0.163038 -0.168068 0.0324817" quat="1 7.81589e-16 -2.27268e-16 6.39239e-16"/>
       <!-- Link shoulder -->
-      <body name="shoulder" pos="0.0207909 -0.0230745 0.0948817" quat="7.88629e-16 -0.707107 -0.707107 7.69003e-16">
+      <body name="shoulder" pos="-0.124202 -0.168068 0.0948817" quat="3.56167e-16 1.22818e-15 -1 -4.14635e-16">
         <!-- Joint from base to shoulder -->
         <joint axis="0 0 1" name="1" type="hinge" range="-1.9198621771937616 1.9198621771937634" class="sts3215"/>
         <inertial pos="-0.0307604 -1.66727e-05 -0.0252713" mass="0.100006" fullinertia="8.3759e-05 8.10403e-05 2.39783e-05 7.55525e-08 -1.16342e-06 1.54663e-07"/>
@@ -53,37 +54,37 @@
         <geom type="mesh" class="visual" pos="-0.0675992 -0.000177759 0.0158499" quat="0.5 0.5 -0.5 0.5" mesh="motor_holder_so101_base_v1" material="motor_holder_so101_base_v1_material"/>
         <geom type="mesh" class="collision" pos="-0.0675992 -0.000177759 0.0158499" quat="0.5 0.5 -0.5 0.5" mesh="motor_holder_so101_base_v1" material="motor_holder_so101_base_v1_material"/>
         <!-- Part rotation_pitch_so101_v1 -->
-        <geom type="mesh" class="visual" pos="0.0122008 2.22413e-05 0.0464" quat="0.707107 -0.707107 0 0" mesh="rotation_pitch_so101_v1" material="rotation_pitch_so101_v1_material"/>
-        <geom type="mesh" class="collision" pos="0.0122008 2.22413e-05 0.0464" quat="0.707107 -0.707107 0 0" mesh="rotation_pitch_so101_v1" material="rotation_pitch_so101_v1_material"/>
+        <geom type="mesh" class="visual" pos="0.0122008 2.22413e-05 0.0464" quat="0.707107 -0.707107 -0 8.3163e-34" mesh="rotation_pitch_so101_v1" material="rotation_pitch_so101_v1_material"/>
+        <geom type="mesh" class="collision" pos="0.0122008 2.22413e-05 0.0464" quat="0.707107 -0.707107 -0 8.3163e-34" mesh="rotation_pitch_so101_v1" material="rotation_pitch_so101_v1_material"/>
         <!-- Link upper_arm -->
         <body name="upper_arm" pos="-0.0303992 -0.0182778 -0.0542" quat="0.5 -0.5 -0.5 -0.5">
           <!-- Joint from shoulder to upper_arm -->
-          <joint axis="0 0 1" name="2" type="hinge" range="-1.7453292519943269 1.7453292519943322" class="sts3215"/>
+          <joint axis="0 0 1" name="2" type="hinge" range="-1.7453292519943224 1.7453292519943366" class="sts3215"/>
           <inertial pos="-0.0898471 -0.00838224 0.0184089" mass="0.103" fullinertia="4.08002e-05 0.000147318 0.000142487 -1.97819e-05 -4.03016e-08 8.97326e-09"/>
           <!-- Part sts3215_03a_v1_3 -->
-          <geom type="mesh" class="visual" pos="-0.11257 -0.0155 0.0187" quat="4.31775e-16 -0.707107 0.707107 -2.94392e-16" mesh="sts3215_03a_v1" material="sts3215_03a_v1_material"/>
-          <geom type="mesh" class="collision" pos="-0.11257 -0.0155 0.0187" quat="4.31775e-16 -0.707107 0.707107 -2.94392e-16" mesh="sts3215_03a_v1" material="sts3215_03a_v1_material"/>
+          <geom type="mesh" class="visual" pos="-0.11257 -0.0155 0.0187" quat="4.56308e-16 -0.707107 0.707107 -1.37383e-16" mesh="sts3215_03a_v1" material="sts3215_03a_v1_material"/>
+          <geom type="mesh" class="collision" pos="-0.11257 -0.0155 0.0187" quat="4.56308e-16 -0.707107 0.707107 -1.37383e-16" mesh="sts3215_03a_v1" material="sts3215_03a_v1_material"/>
           <!-- Part upper_arm_so101_v1 -->
           <geom type="mesh" class="visual" pos="-0.065085 0.012 0.0182" quat="0 1 0 0" mesh="upper_arm_so101_v1" material="upper_arm_so101_v1_material"/>
           <geom type="mesh" class="collision" pos="-0.065085 0.012 0.0182" quat="0 1 0 0" mesh="upper_arm_so101_v1" material="upper_arm_so101_v1_material"/>
           <!-- Link lower_arm -->
-          <body name="lower_arm" pos="-0.11257 -0.028 2.46331e-16" quat="0.707107 -2.94392e-16 -3.85906e-16 0.707107">
+          <body name="lower_arm" pos="-0.11257 -0.028 2.09886e-16" quat="0.707107 -5.98613e-17 -2.58051e-17 0.707107">
             <!-- Joint from upper_arm to lower_arm -->
-            <joint axis="0 0 1" name="3" type="hinge" range="-1.7453292519943295 1.5707963267948966" class="sts3215"/>
+            <joint axis="0 0 1" name="3" type="hinge" range="-1.7453292519943286 1.5707963267948974" class="sts3215"/>
             <inertial pos="-0.0980701 0.00324376 0.0182831" mass="0.104" fullinertia="2.87438e-05 0.000159844 0.00014529 7.41152e-06 1.26409e-06 -4.90188e-08"/>
             <!-- Part under_arm_so101_v1 -->
             <geom type="mesh" class="visual" pos="-0.0648499 -0.032 0.0182" quat="0 1 0 0" mesh="under_arm_so101_v1" material="under_arm_so101_v1_material"/>
             <geom type="mesh" class="collision" pos="-0.0648499 -0.032 0.0182" quat="0 1 0 0" mesh="under_arm_so101_v1" material="under_arm_so101_v1_material"/>
             <!-- Part motor_holder_so101_wrist_v1 -->
-            <geom type="mesh" class="visual" pos="-0.0648499 -0.032 0.018" quat="3.3891e-16 -1 -1.9186e-15 6.33174e-16" mesh="motor_holder_so101_wrist_v1" material="motor_holder_so101_wrist_v1_material"/>
-            <geom type="mesh" class="collision" pos="-0.0648499 -0.032 0.018" quat="3.3891e-16 -1 -1.9186e-15 6.33174e-16" mesh="motor_holder_so101_wrist_v1" material="motor_holder_so101_wrist_v1_material"/>
+            <geom type="mesh" class="visual" pos="-0.0648499 -0.032 0.018" quat="3.92687e-16 -1 -1.9186e-15 -6.38378e-16" mesh="motor_holder_so101_wrist_v1" material="motor_holder_so101_wrist_v1_material"/>
+            <geom type="mesh" class="collision" pos="-0.0648499 -0.032 0.018" quat="3.92687e-16 -1 -1.9186e-15 -6.38378e-16" mesh="motor_holder_so101_wrist_v1" material="motor_holder_so101_wrist_v1_material"/>
             <!-- Part sts3215_03a_v1_4 -->
-            <geom type="mesh" class="visual" pos="-0.1224 0.0052 0.0187" quat="8.32667e-16 -1.56949e-15 -1 5.55112e-16" mesh="sts3215_03a_v1" material="sts3215_03a_v1_material"/>
-            <geom type="mesh" class="collision" pos="-0.1224 0.0052 0.0187" quat="8.32667e-16 -1.56949e-15 -1 5.55112e-16" mesh="sts3215_03a_v1" material="sts3215_03a_v1_material"/>
+            <geom type="mesh" class="visual" pos="-0.1224 0.0052 0.0187" quat="7.21645e-16 1.56949e-15 1 -3.33067e-16" mesh="sts3215_03a_v1" material="sts3215_03a_v1_material"/>
+            <geom type="mesh" class="collision" pos="-0.1224 0.0052 0.0187" quat="7.21645e-16 1.56949e-15 1 -3.33067e-16" mesh="sts3215_03a_v1" material="sts3215_03a_v1_material"/>
             <!-- Link wrist -->
-            <body name="wrist" pos="-0.1349 0.0052 1.65232e-16" quat="0.707107 1.31614e-15 9.90601e-17 -0.707107">
+            <body name="wrist" pos="-0.1349 0.0052 8.44651e-17" quat="0.707107 9.58722e-16 -7.51313e-16 -0.707107">
               <!-- Joint from lower_arm to wrist -->
-              <joint axis="0 0 1" name="4" type="hinge" range="-1.6580627969561903 1.658062781833036" class="sts3215"/>
+              <joint axis="0 0 1" name="4" type="hinge" range="-1.6580628494556928 1.6580627293335335" class="sts3215"/>
               <inertial pos="-0.000103312 -0.0386143 0.0281156" mass="0.079" fullinertia="3.68263e-05 2.5391e-05 2.1e-05 1.7893e-08 -5.28128e-08 3.6412e-06"/>
               <!-- Part sts3215_03a_no_horn_v1 -->
               <geom type="mesh" class="visual" pos="5.55112e-17 -0.0424 0.0306" quat="0.5 0.5 0.5 -0.5" mesh="sts3215_03a_no_horn_v1" material="sts3215_03a_no_horn_v1_material"/>
@@ -92,26 +93,26 @@
               <geom type="mesh" class="visual" pos="0 -0.028 0.0181" quat="0.5 -0.5 -0.5 -0.5" mesh="wrist_roll_pitch_so101_v2" material="wrist_roll_pitch_so101_v2_material"/>
               <geom type="mesh" class="collision" pos="0 -0.028 0.0181" quat="0.5 -0.5 -0.5 -0.5" mesh="wrist_roll_pitch_so101_v2" material="wrist_roll_pitch_so101_v2_material"/>
               <!-- Link gripper -->
-              <body name="gripper" pos="0 -0.0611 0.0181" quat="3.31663e-08 -3.31663e-08 -0.707107 -0.707107">
+              <body name="gripper" pos="2.77556e-16 -0.0611 0.0181" quat="0.0172091 -0.0172091 0.706897 0.706897">
                 <!-- Joint from wrist to gripper -->
-                <joint axis="0 0 1" name="5" type="hinge" range="-2.7925268969992407 2.7925267093826136" class="sts3215"/>
+                <joint axis="0 0 1" name="5" type="hinge" range="-2.7438472969992493 2.841206309382605" class="sts3215"/>
                 <inertial pos="0.000213627 0.000245138 -0.025187" mass="0.087" fullinertia="2.75087e-05 4.33657e-05 3.45059e-05 -3.35241e-07 -5.7352e-06 -5.17847e-08"/>
                 <!-- Part sts3215_03a_v1_5 -->
-                <geom type="mesh" class="visual" pos="0.0077 0.0001 -0.0234" quat="0.707107 -0.707107 6.48145e-15 1.58472e-15" mesh="sts3215_03a_v1" material="sts3215_03a_v1_material"/>
-                <geom type="mesh" class="collision" pos="0.0077 0.0001 -0.0234" quat="0.707107 -0.707107 6.48145e-15 1.58472e-15" mesh="sts3215_03a_v1" material="sts3215_03a_v1_material"/>
+                <geom type="mesh" class="visual" pos="0.0077 0.0001 -0.0234" quat="0.707107 -0.707107 1.66015e-15 6.45947e-15" mesh="sts3215_03a_v1" material="sts3215_03a_v1_material"/>
+                <geom type="mesh" class="collision" pos="0.0077 0.0001 -0.0234" quat="0.707107 -0.707107 1.66015e-15 6.45947e-15" mesh="sts3215_03a_v1" material="sts3215_03a_v1_material"/>
                 <!-- Part wrist_roll_follower_so101_v1 -->
-                <geom type="mesh" class="visual" pos="5.55112e-17 -0.000218214 0.000949706" quat="0 1 0 0" mesh="wrist_roll_follower_so101_v1" material="wrist_roll_follower_so101_v1_material"/>
-                <geom type="mesh" class="collision" pos="5.55112e-17 -0.000218214 0.000949706" quat="0 1 0 0" mesh="wrist_roll_follower_so101_v1" material="wrist_roll_follower_so101_v1_material"/>
-                <!-- Frame gripper -->
-                <site group="3" name="gripper" pos="-0.0079 -0.000218121 -0.0981274" quat="0.5 -0.5 0.5 -0.5"/>
+                <geom type="mesh" class="visual" pos="0 -0.000218214 0.000949706" quat="0 1 0 0" mesh="wrist_roll_follower_so101_v1" material="wrist_roll_follower_so101_v1_material"/>
+                <geom type="mesh" class="collision" pos="0 -0.000218214 0.000949706" quat="0 1 0 0" mesh="wrist_roll_follower_so101_v1" material="wrist_roll_follower_so101_v1_material"/>
+                <!-- Frame gripperframe -->
+                <site group="3" name="gripperframe" pos="-0.0079 -0.000218121 -0.0981274" quat="0.707107 -0 0.707107 -2.37788e-17"/>
                 <!-- Link moving_jaw_so101_v1 -->
-                <body name="moving_jaw_so101_v1" pos="0.0202 0.0188 -0.0234" quat="0.707107 0.707107 1.47485e-15 -6.52758e-15">
+                <body name="moving_jaw_so101_v1" pos="0.0202 0.0188 -0.0234" quat="0.707107 0.707107 -1.85362e-08 1.85362e-08">
                   <!-- Joint from gripper to moving_jaw_so101_v1 -->
-                  <joint axis="0 0 1" name="6" type="hinge" range="-0.17453292519943295 1.7453292519943295" class="sts3215"/>
+                  <joint axis="0 0 1" name="6" type="hinge" range="-0.17453297762778586 1.7453291995659765" class="sts3215"/>
                   <inertial pos="-0.00157495 -0.0300244 0.0192755" mass="0.012" fullinertia="6.61427e-06 1.89032e-06 5.28738e-06 -3.19807e-07 -5.90717e-09 -1.09945e-07"/>
                   <!-- Part moving_jaw_so101_v1 -->
-                  <geom type="mesh" class="visual" pos="-5.55112e-17 -1.94746e-17 0.0189" quat="1 -0 1.86338e-16 6.90343e-24" mesh="moving_jaw_so101_v1" material="moving_jaw_so101_v1_material"/>
-                  <geom type="mesh" class="collision" pos="-5.55112e-17 -1.94746e-17 0.0189" quat="1 -0 1.86338e-16 6.90343e-24" mesh="moving_jaw_so101_v1" material="moving_jaw_so101_v1_material"/>
+                  <geom type="mesh" class="visual" pos="-5.55112e-17 0 0.0189" quat="1 -0 3.00524e-16 -2.00834e-17" mesh="moving_jaw_so101_v1" material="moving_jaw_so101_v1_material"/>
+                  <geom type="mesh" class="collision" pos="-5.55112e-17 0 0.0189" quat="1 -0 3.00524e-16 -2.00834e-17" mesh="moving_jaw_so101_v1" material="moving_jaw_so101_v1_material"/>
                 </body>
               </body>
             </body>
@@ -122,18 +123,18 @@
   </worldbody>
   <asset>
     <mesh file="rotation_pitch_so101_v1.stl"/>
+    <mesh file="wrist_roll_follower_so101_v1.stl"/>
+    <mesh file="sts3215_03a_no_horn_v1.stl"/>
+    <mesh file="under_arm_so101_v1.stl"/>
+    <mesh file="base_motor_holder_so101_v1.stl"/>
+    <mesh file="wrist_roll_pitch_so101_v2.stl"/>
     <mesh file="moving_jaw_so101_v1.stl"/>
     <mesh file="sts3215_03a_v1.stl"/>
-    <mesh file="motor_holder_so101_wrist_v1.stl"/>
-    <mesh file="wrist_roll_follower_so101_v1.stl"/>
-    <mesh file="base_so101_v2.stl"/>
-    <mesh file="under_arm_so101_v1.stl"/>
-    <mesh file="wrist_roll_pitch_so101_v2.stl"/>
-    <mesh file="waveshare_mounting_plate_so101_v2.stl"/>
-    <mesh file="sts3215_03a_no_horn_v1.stl"/>
     <mesh file="motor_holder_so101_base_v1.stl"/>
-    <mesh file="base_motor_holder_so101_v1.stl"/>
+    <mesh file="base_so101_v2.stl"/>
     <mesh file="upper_arm_so101_v1.stl"/>
+    <mesh file="waveshare_mounting_plate_so101_v2.stl"/>
+    <mesh file="motor_holder_so101_wrist_v1.stl"/>
     <material name="base_motor_holder_so101_v1_material" rgba="0.964706 0.964706 0.952941 1"/>
     <material name="base_so101_v2_material" rgba="0.964706 0.964706 0.952941 1"/>
     <material name="sts3215_03a_v1_material" rgba="0.627451 0.627451 0.627451 1"/>


### PR DESCRIPTION
- Updates `so101_new_calib.urdf` and `so101_new_calib.xml`
- Fix  flipped y-axis
- adds `baseframe` and `gripperframe` to have  proper frames for the base and end effector to be compatible with kinematics packages like placo. Check [PR#1322](https://github.com/huggingface/lerobot/pull/1322)